### PR TITLE
Fix module docstring layout

### DIFF
--- a/custom_components/govee_light_automation/__init__.py
+++ b/custom_components/govee_light_automation/__init__.py
@@ -1,6 +1,5 @@
-"""The Govee Light Automation integration."""
-"""
-Govee Light Automation Integration for Home Assistant
+"""Govee Light Automation integration for Home Assistant.
+
 Author: Shiv Kumar Ganesh (gshiv.sk@gmail.com)
 """
 
@@ -70,4 +69,4 @@ CONFIG_SCHEMA = vol.Schema(
             }
         )
     }
-) 
+)


### PR DESCRIPTION
## Summary
- consolidate module documentation into a single top-level docstring
- keep `from __future__ import annotations` as the first statement

## Testing
- `pip install homeassistant` *(fails: Could not find a version that satisfies the requirement homeassistant)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_6896f9f122748322abb081a153179836